### PR TITLE
quote card min-w-96

### DIFF
--- a/src/components/quote-card/quote-card.tsx
+++ b/src/components/quote-card/quote-card.tsx
@@ -42,7 +42,7 @@ export const QuoteCard: React.FC = () => {
   return (
     <div
       id="quote-box"
-      className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-90 h-50 bg-blue-400 flex flex-col justify-center items-center text-white rounded-lg shadow-lg p-4"
+      className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-90 h-50 bg-blue-400 flex flex-col justify-center items-center text-white rounded-lg shadow-lg p-4 min-w-96"
       role="dialog"
       aria-labelledby="quote-text"
       aria-describedby="quote-author"


### PR DESCRIPTION
### TL;DR

Added minimum width to quote box for better responsiveness.

### What changed?

Added `min-w-96` class to the quote box div in the QuoteCard component, setting a minimum width of 96 units (likely pixels or rem, depending on the Tailwind configuration).

### Why make this change?

This change ensures that the quote box maintains a minimum width, preventing it from becoming too narrow on smaller screens or when the window is resized. This improves readability and maintains a consistent layout across different device sizes, enhancing the overall user experience.

---

